### PR TITLE
add GDT to readme

### DIFF
--- a/examples/containerstominiyaml/implementationArtefacts/emf-syncer_ttc2023_container2miniyaml/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/containerstominiyaml/implementationArtefacts/emf-syncer_ttc2023_container2miniyaml/.settings/org.eclipse.jdt.core.prefs
@@ -1,11 +1,11 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=17

--- a/examples/containerstominiyaml/implementationArtefacts/emf-syncer_ttc2023_container2miniyaml/readme.md
+++ b/examples/containerstominiyaml/implementationArtefacts/emf-syncer_ttc2023_container2miniyaml/readme.md
@@ -5,4 +5,4 @@ The solutions can be found under `./src/main/groovy/containerstominiyaml/yamtl`:
 * Backward transformation: `MiniYAML2Containers.groovy`
 * Benchmark driver: `YAMTLContainersToMiniYAML_BXTool.java`
 
-To import the project in the Eclipse IDE, you'll need the Groovy Development Tools plugin.
+To import the project in the Eclipse IDE, you'll need the [Groovy Development Tools plugin](https://marketplace.eclipse.org/content/groovy-development-tools) from the Eclipse Marketplace.

--- a/examples/containerstominiyaml/implementationArtefacts/emf-syncer_ttc2023_container2miniyaml/readme.md
+++ b/examples/containerstominiyaml/implementationArtefacts/emf-syncer_ttc2023_container2miniyaml/readme.md
@@ -1,6 +1,8 @@
 # YAMTL+EMF-Syncer solution to TTC2023 Containers to MiniYAML case
 
-The solutions can be found under `./src/main/java/containerstominiyaml/yamtl`:
+The solutions can be found under `./src/main/groovy/containerstominiyaml/yamtl`:
 * Forward transformation: `YAMTLContainersToMiniYAML.groovy` 
 * Backward transformation: `MiniYAML2Containers.groovy`
 * Benchmark driver: `YAMTLContainersToMiniYAML_BXTool.java`
+
+To import the project in the Eclipse IDE, you'll need the Groovy Development Tools plugin.


### PR DESCRIPTION
I have added that GDT is required for importing the project into Eclipse.